### PR TITLE
fix(chat-room): prevent duplicate room creation by enforcing title un…

### DIFF
--- a/chat-service/src/main/java/com/trendchat/chatservice/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/controller/ChatRoomController.java
@@ -4,15 +4,14 @@ import com.trendchat.chatservice.dto.ChatRoomResponse;
 import com.trendchat.chatservice.entity.ChatRoom;
 import com.trendchat.chatservice.service.ChatRoomService;
 import java.util.List;
+import java.util.Optional;
 
 import com.trendchat.trendchatcommon.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,9 +30,20 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.getChatRoomByIdResponse(roomId, authUser.getUserId()));
     }
 
-    // 프론트에서 title만 넣으면 자동 조회/생성
+    // 조회 전용 (존재하는 채팅방만 조회)
     @GetMapping("/title/{title}")
-    public ResponseEntity<ChatRoomResponse> getOrCreateByTitle(@PathVariable String title, @AuthenticationPrincipal AuthUser authUser) {
-        return ResponseEntity.ok(chatRoomService.getOrCreateByTitle(title, authUser.getUserId()));
+    public ResponseEntity<ChatRoomResponse> getByTitle(@PathVariable String title, @AuthenticationPrincipal AuthUser authUser) {
+        Optional<ChatRoomResponse> response = chatRoomService.findResponseByTitle(title, authUser.getUserId());
+
+        return response
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
+
+    // 생성 전용 (없으면 새로 생성)
+    @PostMapping("/title/{title}")
+    public ResponseEntity<ChatRoomResponse> createByTitle(@PathVariable String title, @AuthenticationPrincipal AuthUser authUser) {
+        return ResponseEntity.ok(chatRoomService.createByTitle(title, authUser.getUserId()));
+    }
+
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/entity/ChatRoom.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/entity/ChatRoom.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,7 @@ public class ChatRoom {
     private String description;
     private LocalDateTime createdAt;
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ChatMessage> messages;
+    private List<ChatMessage> messages = new ArrayList<>();
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomRepository.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomRepository.java
@@ -23,4 +23,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     WHERE r.title = :title
 """)
     Optional<ChatRoom> findByTitleWithMessages(@Param("title") String title);
+
+    Optional<ChatRoom> findByTitle(String title);
+
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.trendchat.chatservice.service;
 import com.trendchat.chatservice.dto.ChatRoomResponse;
 import com.trendchat.chatservice.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomService {
 
@@ -14,5 +15,7 @@ public interface ChatRoomService {
 
     ChatRoom getChatRoomById(Long roomId);
 
-    ChatRoomResponse getOrCreateByTitle(String title, String currentUserId);
+    Optional<ChatRoomResponse> findResponseByTitle(String title, String currentUserId);
+
+    ChatRoomResponse createByTitle(String title, String userId);
 }


### PR DESCRIPTION
…iqueness

- ChatRoomService에서 findOrCreateByTitle 흐름 분리
- 기존 GET 실패 시에만 방 생성하도록 안전하게 처리
- 응답 DTO 정제 및 메시지/참가자 목록 로딩 안정화