### PR TITLE
feat: 채팅방 인기 통계 API 구현 및 전체 채팅방 정보 조회 DTO 추가

### DIFF
--- a/chat-service/src/main/java/com/trendchat/chatservice/config/SecurityConfig.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                 .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/api/v1/chat/stream").permitAll()
+                        .pathMatchers("/api/v1/rooms/**").permitAll()
                                 .anyExchange().authenticated()
                 )
                 .addFilterAt(authorizationFilter, SecurityWebFiltersOrder.AUTHORIZATION)

--- a/chat-service/src/main/java/com/trendchat/chatservice/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/controller/ChatRoomController.java
@@ -1,17 +1,19 @@
 package com.trendchat.chatservice.controller;
 
+import com.trendchat.chatservice.dto.ChatRoomListResponse;
 import com.trendchat.chatservice.dto.ChatRoomResponse;
-import com.trendchat.chatservice.entity.ChatRoom;
+import com.trendchat.chatservice.dto.ChatRoomStatsResponse;
 import com.trendchat.chatservice.service.ChatRoomService;
-import java.util.List;
-import java.util.Optional;
-
 import com.trendchat.trendchatcommon.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +23,8 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @GetMapping
-    public List<ChatRoom> getAllChatRooms() {
-        return chatRoomService.getAllChatRooms();
+    public ResponseEntity<List<ChatRoomListResponse>> getAllChatRooms() {
+        return ResponseEntity.ok(chatRoomService.getAllChatRooms());
     }
 
     @GetMapping("/{roomId}")
@@ -46,4 +48,21 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.createByTitle(title, authUser.getUserId()));
     }
 
+    // 일부 list & top5 list받으면 그것만 통계
+    @PostMapping("/stats/bulk")
+    public ResponseEntity<Map<Long, ChatRoomStatsResponse>> getRoomStats(@RequestBody List<Long> roomIds) {
+        return ResponseEntity.ok(chatRoomService.getRoomStats(roomIds));
+    }
+
+    // 전체 방 통계
+    @GetMapping("/stats/all")
+    public ResponseEntity<Map<Long, ChatRoomStatsResponse>> getAllStats() {
+        return ResponseEntity.ok(chatRoomService.getAllRoomStats());
+    }
+
+    // 상위 5개 방 ID
+    @GetMapping("/stats/top5")
+    public ResponseEntity<List<Long>> getTop6RoomIds() {
+        return ResponseEntity.ok(chatRoomService.getTop6ActiveRoomIds());
+    }
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/dto/ChatRoomListResponse.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/dto/ChatRoomListResponse.java
@@ -1,0 +1,13 @@
+package com.trendchat.chatservice.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatRoomListResponse(
+        Long id,
+        String title,
+        String description,
+        LocalDateTime createdAt
+) {}

--- a/chat-service/src/main/java/com/trendchat/chatservice/dto/ChatRoomStatsResponse.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/dto/ChatRoomStatsResponse.java
@@ -1,0 +1,10 @@
+package com.trendchat.chatservice.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomStatsResponse(
+        int participants,
+        int messageCount
+) {
+}

--- a/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatMessageRepository.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatMessageRepository.java
@@ -3,8 +3,10 @@ package com.trendchat.chatservice.repository;
 import com.trendchat.chatservice.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     List<ChatMessage> findByChatRoomIdOrderByTimestampAsc(Long roomId);
+    int countByChatRoomIdAndTimestampAfter(Long roomId, LocalDateTime timestamp);
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomMemberRepository.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomMemberRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
     List<ChatRoomMember> findByChatRoomId(Long roomdId);
     boolean existsByChatRoomIdAndUserId(Long roomId, String userId);
+    int countByChatRoomId(Long roomId);
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomRepository.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/repository/ChatRoomRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
@@ -26,4 +28,16 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     Optional<ChatRoom> findByTitle(String title);
 
+    @Query("SELECT r.id FROM ChatRoom r")
+    List<Long> findAllRoomIds();
+
+    @Query("""
+        SELECT m.chatRoom.id, COUNT(m)
+        FROM ChatMessage m
+        WHERE m.timestamp > :after
+        GROUP BY m.chatRoom.id
+        ORDER BY COUNT(m) DESC
+        LIMIT 6
+    """)
+    List<Object[]> findTop6ActiveRooms(@Param("after") LocalDateTime after);
 }

--- a/chat-service/src/main/java/com/trendchat/chatservice/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/trendchat/chatservice/service/ChatRoomService.java
@@ -1,15 +1,18 @@
 package com.trendchat.chatservice.service;
 
+import com.trendchat.chatservice.dto.ChatRoomListResponse;
 import com.trendchat.chatservice.dto.ChatRoomResponse;
+import com.trendchat.chatservice.dto.ChatRoomStatsResponse;
 import com.trendchat.chatservice.entity.ChatRoom;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ChatRoomService {
 
     boolean createChatRoom(String title, String description);
 
-    List<ChatRoom> getAllChatRooms();
+    List<ChatRoomListResponse> getAllChatRooms();
 
     ChatRoomResponse getChatRoomByIdResponse(Long roomId, String currentUserId);
 
@@ -18,4 +21,10 @@ public interface ChatRoomService {
     Optional<ChatRoomResponse> findResponseByTitle(String title, String currentUserId);
 
     ChatRoomResponse createByTitle(String title, String userId);
+
+    Map<Long, ChatRoomStatsResponse> getRoomStats(List<Long> roomIds);
+
+    Map<Long, ChatRoomStatsResponse> getAllRoomStats();
+
+    List<Long> getTop6ActiveRoomIds();
 }


### PR DESCRIPTION
- 최근 30분간 메시지 수 기반 Top 6 채팅방 조회 API (/stats/top6) 구현
- 채팅방 ID 목록 기반 통계 조회 API (/stats/bulk) 구현
- 전체 채팅방 통계 API (/stats/all) 추가
- LazyLoading 방지용 ChatRoomListResponse DTO 생성
- /rooms API 응답을 ChatRoomListResponse로 리팩토링